### PR TITLE
Tuples, one push.

### DIFF
--- a/con4m.nimble
+++ b/con4m.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.2"
+version       = "0.2.3"
 author        = "John Viega"
 description   = "A generic configuration file format that allows for lightweight scripting. Inspired by HCL, but far more straightforward.  Yet far more functional than UCL."
 license       = "Apache-2.0"

--- a/docs/langref.md
+++ b/docs/langref.md
@@ -18,18 +18,21 @@ coreBodyItems ::= attrAssign | varAssign | section | ifStmt | forStmt |
                    whileStmt | breakStmt | expression (NL|";")+
 enum          ::= "enum" ID ("," ID)*		   
 attrAssign    ::= ID ("="|":") expression (NL|";")+
-varAssign     ::= ID ":=" expression (NL|";")+
+varAssign     ::= ID ("," ID)* ":=" expression (NL|";")+
 section       ::= ID (STR | ID)* "{" body "}" 
 ifStmt        ::= "if" expression "{" body "}" 
                   ("elif" expression "{" body "}")*
 	 	              ("else" expression "{" body" "}")?
 forStmt       ::= "for" ID "from" expression "to" expression "{" body "}"
 breakStmt     ::= "break" (";")?
+# Note that literal matches before accessExpr, so a lparen at an exprStart
+# or in a unaryExpr will be treated as a tuple literal.
 exprStart     ::= unaryExpr | notExpr | literal | accessExpr
 unaryExpr     ::= ("+" | "-") (literal | accessExpr)
 notExpr       ::= ("!" | "not") expression
 literal       ::= NUM | STR | listLiteral | dictLiteral | TRUE | FALSE | NULL
 accessExpr    ::= (ID | parenExpr) (memberExpr | indexExpr | callActuals)* 
+tupleLiteral  ::= "(" expression ("," expression)*)+ ")"
 listLiteral   ::= "[" (expression ("," expression)* )? "]"
 dictLiteral   ::= "{" (expression ":" expression
                        ("," expression ":" expression)*) "}"

--- a/src/con4m.nim
+++ b/src/con4m.nim
@@ -50,8 +50,8 @@ export codegen.con4m, configDef
 
 when defined(testCases):
   # There are really just exposed for our tests.  Should change that.
-   import con4m/st
-   export lookupAttr
-   import con4m/dollars
-   export dollars
+    import con4m/st
+    export lookupAttr
+    import con4m/dollars
+    export dollars
 

--- a/src/con4m/builtins.nim
+++ b/src/con4m/builtins.nim
@@ -389,7 +389,7 @@ proc builtInDictLen*(args: seq[Box],
   var dict = unbox[TableRef[Box, Box]](args[0])
 
   return some(box(len(dict)))
-
+                       
 when defined(posix):
   proc builtinCmd*(args: seq[Box],
                    unused1: Con4mScope,
@@ -450,6 +450,7 @@ else:
       exitAsStr = $(exitCode)
 
     return some(box("{exitAsStr}:{output}".fmt()))
+
 
 proc newBuiltIn*(s: ConfigState, name: string, fn: BuiltInFn, tinfo: string) =
   ## Allows you to associate a NIM function with the correct signature

--- a/src/con4m/builtins.nim
+++ b/src/con4m/builtins.nim
@@ -433,6 +433,38 @@ when defined(posix):
 
     if (uid != euid): discard seteuid(euid)
     if (gid != egid): discard setegid(egid)
+
+  proc builtinSystem*(args: seq[Box],
+                   unused1: Con4mScope,
+                   unused2: Con4mScope): Option[Box] =
+    ## Generally exposed as `system(s)`
+    ##
+    ## like `run` except returns a tuple containing the output and the exit code.
+    var
+      cmd = unbox[string](args[0])
+    let
+      uid = getuid()
+      euid = geteuid()
+      gid = getgid()
+      egid = getegid()
+
+    if (uid != euid) or (gid != egid):
+      discard seteuid(uid)
+      discard setegid(gid)
+
+    let (output, exitCode) = execCmdEx(cmd)
+
+    var outlist: seq[Box] = @[]
+
+    outlist.add(box(output))
+    outlist.add(box(exitCode))
+    
+    result = some(boxList[Box](outlist))
+    # TODO: When adding tuples, also return the exit code.
+
+    if (uid != euid): discard seteuid(euid)
+    if (gid != egid): discard setegid(egid)
+    
 else:
   ## I don't know the permissions models on any non-posix OS, so
   ## this might be wildly insecure on such systems, as far as I know.
@@ -475,34 +507,35 @@ proc addDefaultBuiltins*(s: ConfigState) =
   ## Instead, you probably should just use `newBuiltIn()` to add your
   ## own calls, unless you want to remove or rename things.
 
-  s.newBuiltIn("string", builtinBToS, "(bool) -> string")
-  s.newBuiltIn("string", builtinIToS, "(int) -> string")
-  s.newBuiltIn("string", builtinFToS, "(float) -> string")
-  s.newBuiltIn("bool", builtinIToB, "(int) -> bool")
-  s.newBuiltIn("bool", builtinFToB, "(float) -> bool")
-  s.newBuiltIn("bool", builtinSToB, "(string) -> bool")
-  s.newBuiltIn("bool", builtinLToB, "([@x]) -> bool")
-  s.newBuiltIn("bool", builtinDToB, "({@x : @y}) -> bool")
-  s.newBuiltIn("float", builtinItoF, "(int) -> float")
-  s.newBuiltIn("int", builtinFtoI, "(float) -> int")
-  s.newBuiltIn("split", builtinSplit, "(string, string) -> [string]")
-  s.newBuiltIn("echo", builtinEcho, "(*string)")
-  s.newBuiltIn("env", builtinEnv, "(string) -> string")
-  s.newBuiltIn("envExists", builtinEnvExists, "(string) -> bool")
-  s.newBuiltIn("env", builtinEnvAll, "() -> {string : string}")
-  s.newBuiltIn("strip", builtinStrip, "(string) -> string")
-  s.newBuiltIn("contains", builtinContainsStrStr, "(string, string) -> bool")
-  s.newBuiltIn("find", builtinFindFromStart, "(string, string) -> int")
-  s.newBuiltIn("slice", builtinSlice, "(string, int, int) -> string")
-  s.newBuiltIn("slice", builtinSliceToEnd, "(string, int) -> string")
-  s.newBuiltIn("abort", builtInAbort, "(string)")
-  s.newBuiltIn("len", builtInStrLen, "(string) -> int")
-  s.newBuiltIn("len", builtInListLen, "([@x]) -> int")
-  s.newBuiltIn("len", builtInDictLen, "({@x : @y}) -> int")
-  s.newBuiltIn("format", builtInFormat, "(string) -> string")
+  s.newBuiltIn("string", builtinBToS, "f(bool) -> string")
+  s.newBuiltIn("string", builtinIToS, "f(int) -> string")
+  s.newBuiltIn("string", builtinFToS, "f(float) -> string")
+  s.newBuiltIn("bool", builtinIToB, "f(int) -> bool")
+  s.newBuiltIn("bool", builtinFToB, "f(float) -> bool")
+  s.newBuiltIn("bool", builtinSToB, "f(string) -> bool")
+  s.newBuiltIn("bool", builtinLToB, "f([@x]) -> bool")
+  s.newBuiltIn("bool", builtinDToB, "f({@x : @y}) -> bool")
+  s.newBuiltIn("float", builtinItoF, "f(int) -> float")
+  s.newBuiltIn("int", builtinFtoI, "f(float) -> int")
+  s.newBuiltIn("split", builtinSplit, "f(string, string) -> [string]")
+  s.newBuiltIn("echo", builtinEcho, "f(*string)")
+  s.newBuiltIn("env", builtinEnv, "f(string) -> string")
+  s.newBuiltIn("envExists", builtinEnvExists, "f(string) -> bool")
+  s.newBuiltIn("env", builtinEnvAll, "f() -> {string : string}")
+  s.newBuiltIn("strip", builtinStrip, "f(string) -> string")
+  s.newBuiltIn("contains", builtinContainsStrStr, "f(string, string) -> bool")
+  s.newBuiltIn("find", builtinFindFromStart, "f(string, string) -> int")
+  s.newBuiltIn("slice", builtinSlice, "f(string, int, int) -> string")
+  s.newBuiltIn("slice", builtinSliceToEnd, "f(string, int) -> string")
+  s.newBuiltIn("abort", builtInAbort, "f(string)")
+  s.newBuiltIn("len", builtInStrLen, "f(string) -> int")
+  s.newBuiltIn("len", builtInListLen, "f([@x]) -> int")
+  s.newBuiltIn("len", builtInDictLen, "f({@x : @y}) -> int")
+  s.newBuiltIn("format", builtInFormat, "f(string) -> string")
 
   when defined(posix):
-    s.newBuiltIn("run", builtinCmd, "(string) -> string")
+    s.newBuiltIn("run", builtinCmd, "f(string) -> string")
+    s.newBuiltIn("system", builtinSystem, "f(string) -> (string, int)")
 
 proc getBuiltinBySig*(s: ConfigState,
                       name: string,

--- a/src/con4m/dollars.nim
+++ b/src/con4m/dollars.nim
@@ -62,14 +62,14 @@ proc `$`*(t: Con4mType): string =
   of TypeTVar: return "@{t.varNum}".fmt()
   of TypeBottom: return "⊥"
   of TypeProc:
-    if t.params.len() == 0: return "() -> {$(t.retType)}".fmt()
+    if t.params.len() == 0: return "f() -> {$(t.retType)}".fmt()
     else:
       var paramTypes: seq[string]
       for item in t.params:
         paramTypes.add($(item))
       if t.va:
         paramTypes[^1] = "*" & paramTypes[^1]
-      return "({paramTypes.join(\", \")}) -> {$(t.retType)}".fmt()
+      return "f({paramTypes.join(\", \")}) -> {$(t.retType)}".fmt()
 
 proc formatNonTerm(self: Con4mNode, name: string, i: int): string
 

--- a/src/con4m/dollars.nim
+++ b/src/con4m/dollars.nim
@@ -54,6 +54,11 @@ proc `$`*(t: Con4mType): string =
   of TypeFloat: return "float"
   of TypeList: return "[{t.itemType}]".fmt()
   of TypeDict: return "{{{t.keyType} : {t.valType}}}".fmt()
+  of TypeTuple:
+    var s: seq[string]
+    for item in t.itemTypes:
+      s.add($(item))
+    return fmt"""({s.join(", ")})"""
   of TypeTVar: return "@{t.varNum}".fmt()
   of TypeBottom: return "⊥"
   of TypeProc:
@@ -90,6 +95,7 @@ proc `$`*(self: Con4mNode, i: int = 0): string =
   of NodeBody: fmtNt("Body")
   of NodeAttrAssign: fmtNt("AttrAssign")
   of NodeVarAssign: fmtNt("VarAssign")
+  of NodeUnpack: fmtNt("Unpack")
   of NodeSection: fmtNt("Section")
   of NodeIfStmt: fmtNt("If Stmt")
   of NodeConditional: fmtNt("Conditional")
@@ -107,6 +113,7 @@ proc `$`*(self: Con4mNode, i: int = 0): string =
   of NodeDictLit: fmtNt("DictLit")
   of NodeKVPair: fmtNt("KVPair")
   of NodeListLit: fmtNt("ListLit")
+  of NodeTupleLit: fmtNt("TupleLit")
   of NodeEnum: fmtNt("Enum")
   of NodeOr, NodeAnd, NodeNe, NodeCmp, NodeGte, NodeLte, NodeGt,
      NodeLt, NodePlus, NodeMinus, NodeMod, NodeMul, NodeDiv:

--- a/src/con4m/parse.nim
+++ b/src/con4m/parse.nim
@@ -329,10 +329,14 @@ proc tupleLiteral(ctx: ParseCtx): Con4mNode =
     case ctx.consume().kind
     of TtRParen:
       ctx.nlWatch = watch
-      
-      if len(result.children) < 2:
-        parseError("Tuples must have two or more items.")
-      return
+
+      case result.children.len()
+      of 0:
+        parseError("Cannot have an empty tuple.")
+      of 1:
+        return result.children[0]
+      else:
+        return
     of TtComma:
       continue
     else:

--- a/src/con4m/st.nim
+++ b/src/con4m/st.nim
@@ -183,11 +183,38 @@ proc toCon4mType(s: string, tv: TableRef): (Con4mType, string) =
     return (newDictType(keyT, valT), n[1 .. ^1])
   elif n[0] == '(':
     var
+      argtypes: seq[Con4mType]
+      oneArgType: Con4mType
+
+    n = unicode.strip(n[1 .. ^1])
+    
+    while true:
+      (oneArgType, n) = n.toCon4mType(tv)
+      argTypes.add(oneArgType)
+      n = unicode.strip(n[0 .. ^1])
+      case n[0]
+      of ',':
+        n = unicode.strip(n[1 .. ^1])
+      of ')':
+        if len(argTypes) < 2:
+          raise newException(ValueError, "Tuples must have 2 or more items")
+        n = unicode.strip(n[1 .. ^1])
+        return (Con4mType(kind: TypeTuple, itemTypes: argTypes), n)
+      else:
+        raise newException(ValueError, "Invalid function type spec")
+  elif n[0] == 'f':
+    var
       params: seq[Con4mType]
       oneParam: Con4mType
       va: bool
 
     n = unicode.strip(n[1 .. ^1])
+    
+    if n[0] != '(':
+      raise newException(ValueError, "Function types are written: f() -> ...")
+      
+    n = unicode.strip(n[1 .. ^1])      
+    
     if n[0] == ')':
       n = unicode.strip(n[1 .. ^1])
     else:

--- a/src/con4m/types.nim
+++ b/src/con4m/types.nim
@@ -38,22 +38,24 @@ type
     ## exposed either, other than the fact that they're contained in
     ## state objects that are the primary object type exposed to the
     ## user.
-    NodeBody, NodeAttrAssign, NodeVarAssign, NodeSection, NodeIfStmt,
-    NodeConditional, NodeElse, NodeFor, NodeBreak, NodeContinue, NodeSimpLit,
-    NodeUnary, NodeNot, NodeMember, NodeIndex, NodeActuals, NodeCall,
-    NodeDictLit, NodeKVPair, NodeListLit, NodeOr, NodeAnd, NodeNe, NodeCmp,
-    NodeGte, NodeLte, NodeGt, NodeLt, NodePlus, NodeMinus, NodeMod, NodeMul,
-    NodeDiv, NodeEnum, NodeIdentifier
+    NodeBody, NodeAttrAssign, NodeVarAssign, NodeUnpack, NodeSection,
+    NodeIfStmt, NodeConditional, NodeElse, NodeFor, NodeBreak, NodeContinue,
+    NodeSimpLit, NodeUnary, NodeNot, NodeMember, NodeIndex, NodeActuals,
+    NodeCall, NodeDictLit, NodeKVPair, NodeListLit, NodeTupleLit, NodeOr,
+    NodeAnd, NodeNe, NodeCmp, NodeGte, NodeLte, NodeGt, NodeLt, NodePlus,
+    NodeMinus, NodeMod, NodeMul, NodeDiv, NodeEnum, NodeIdentifier
 
   Con4mTypeKind* = enum
     ## The enumeration of possible top-level types in Con4m
-    TypeString, TypeBool, TypeInt, TypeFloat, TypeList, TypeDict, TypeProc,
-    TypeTVar, TypeBottom
+    TypeString, TypeBool, TypeInt, TypeFloat, TypeTuple, TypeList, TypeDict,
+    TypeProc, TypeTVar, TypeBottom
 
   Con4mType* = ref object
     ## The internal representation of a type.  Generally, you should
     ## write strings, and con4m will parse them.
     case kind*: Con4mTypeKind
+    of TypeTuple:
+      itemTypes*: seq[Con4mType]
     of TypeList:
       itemType*: Con4mType
     of TypeDict:

--- a/tests/dontrun.test8.nim
+++ b/tests/dontrun.test8.nim
@@ -189,7 +189,7 @@ key "SBOMS" {
     since: "0.1.0"
 }
 """
-        
+
 
 test "samiconf":
   addHandler(newConsoleLogger(fmtStr = "$appname: $levelname: "))
@@ -224,7 +224,7 @@ test "samiconf":
       attr("codec", bool, false)
       attr("docstring", string, required = false)
 
-      
+
   echo "log level: ", conf.log_level
   echo "artifact path: ", conf.artifact_search_path
   echo "config file path: ", conf.config_path

--- a/tests/test2.nim
+++ b/tests/test2.nim
@@ -5,7 +5,7 @@ import options
 
 test "manual inspection":
   addHandler(newConsoleLogger(fmtStr = "$appname: $levelname: "))
-  
+
   var s = """
 
 defaults {

--- a/tests/test3.nim
+++ b/tests/test3.nim
@@ -10,8 +10,8 @@ test "hello, world":
 
   var
     state: ConfigState
-    cfg:   Option[Con4mScope]
-    
+    cfg: Option[Con4mScope]
+
   let opt = evalConfig(conffile)
 
   check opt.isSome()

--- a/tests/test4.nim
+++ b/tests/test4.nim
@@ -41,7 +41,7 @@ test "hello, world":
   itemSection.addAttr("foo", "int")
   itemSection.addAttr("bar", "int", required = false)
   itemSection.addAttr("boz", "int", required = false)
-  
+
   let tree = parse(newStringStream(conffile))
 
   check tree != nil
@@ -52,7 +52,7 @@ test "hello, world":
 
 
   ctx.addSpec(spec)
-  
+
   check not ctx.validateConfig()
   for item in ctx.errors:
     echo item

--- a/tests/test5.nim
+++ b/tests/test5.nim
@@ -42,8 +42,8 @@ test "hello, world":
   spec.addGlobalAttr("fart", "bool", required = false)
   spec.addGlobalAttr("test1", "string")
   spec.addGlobalAttr("test2", "string")
-  spec.addGlobalAttr("s", "string")    
-  
+  spec.addGlobalAttr("s", "string")
+
   var defaultSection = spec.addSection("defaults")
   defaultSection.addAttr("test", "bool")
 
@@ -58,11 +58,11 @@ test "hello, world":
   check tree != nil
 
   let ctx = tree.evalTree().getOrElse(nil)
-    
+
   check ctx != nil
-    
+
   ctx.addSpec(spec)
-  
+
   check ctx.validateConfig()
 
   for item in ctx.errors:
@@ -70,4 +70,4 @@ test "hello, world":
 
   check unbox[int](ctx.getConfigVar("item.okay.foo").get()) == 2
   check unbox[string](ctx.getConfigVar("s").get()) == "set an example!"
-  
+

--- a/tests/test6.nim
+++ b/tests/test6.nim
@@ -47,16 +47,16 @@ test "hello, world":
   var itemSection = spec.addSection("item", validSubSecs = @["*"])
   itemSection.addAttr("foo", "int")
   itemSection.addAttr("bar", "int", required = false)
-  itemSection.addAttr("boz", "int", required = false)    
+  itemSection.addAttr("boz", "int", required = false)
 
   let
     tree = parse(newStringStream(conffile))
-    
+
   check tree != nil
 
   let ctx = tree.evalTree().getOrElse(nil)
   check ctx != nil
-  
+
   ctx.addSpec(spec)
   check ctx.validateConfig()
 

--- a/tests/test7.nim
+++ b/tests/test7.nim
@@ -193,7 +193,7 @@ key "SBOMS" {
     since: "0.1.0"
 }
 """
-        
+
 type
   SamiKeySection = ref object
     required: bool
@@ -210,7 +210,7 @@ type
     value: Option[Box]
     codec: bool
     docstring: Option[string]
-      
+
   SamiConf = ref object
     config_path: seq[string]
     config_filename: string
@@ -230,7 +230,7 @@ proc loadSamiConfig(ctx: ConfigState): SamiConf =
   var tmpBox: Box
 
   tmpBox = ctx.getConfigVar("config_path").get()
-  
+
   let config_path_box_seq_str = unboxList[Box](tmpBox)
   var config_path_seq_str: seq[string] = @[]
 
@@ -241,24 +241,24 @@ proc loadSamiConfig(ctx: ConfigState): SamiConf =
 
   tmpBox = ctx.getConfigVar("config_filename").get()
   result.config_filename = unbox[string](tmpBox)
-  
+
   tmpBox = ctx.getConfigVar("color").get()
   result.color = unbox[bool](tmpBox)
-  
+
   tmpBox = ctx.getConfigVar("log_level").get()
   result.log_level = unbox[string](tmpBox)
-  
+
   tmpBox = ctx.getConfigVar("dry_run").get()
-  result.dry_run  = unbox[bool](tmpBox)
+  result.dry_run = unbox[bool](tmpBox)
 
   tmpBox = ctx.getConfigVar("artifact_search_path").get()
-  
+
   let artifact_search_path_box_seq_str = unboxList[Box](tmpBox)
   var artifact_search_path_seq_str: seq[string] = @[]
 
   for item in artifact_search_path_box_seq_str:
     artifact_search_path_seq_str.add(unbox[string](item))
-    
+
   result.artifact_search_path = artifact_search_path_seq_str
 
   tmpBox = ctx.getConfigVar("recursive").get()
@@ -275,7 +275,7 @@ proc loadSamiConfig(ctx: ConfigState): SamiConf =
   for (toplevel, k, v) in sectionInfo:
     var stEntry: STEntry
     var entryOpt: Option[STEntry]
-    
+
     let sectionKey = k.split(".")[1 .. ^1].join(".")
     var sectionData = SamiKeySection()
     result.key[sectionKey] = sectionData
@@ -295,7 +295,7 @@ proc loadSamiConfig(ctx: ConfigState): SamiConf =
     stEntry = v.lookupAttr("squash").get()
     tmpBox = stEntry.value.get()
     sectionData.squash = unbox[bool](tmpBox)
-    
+
     stEntry = v.lookupAttr("standard").get()
     tmpBox = stEntry.value.get()
     sectionData.standard = unbox[bool](tmpBox)
@@ -318,7 +318,7 @@ proc loadSamiConfig(ctx: ConfigState): SamiConf =
       if stEntry.value.isSome():
         tmpBox = stEntry.value.get()
         sectionData.priority = some(unbox[int](tmpBox))
-    
+
     entryOpt = v.lookupAttr("since")
     if entryOpt.isSome():
       stEntry = entryOpt.get()
@@ -339,7 +339,7 @@ proc loadSamiConfig(ctx: ConfigState): SamiConf =
     stEntry = v.lookupAttr("codec").get()
     tmpBox = stEntry.value.get()
     sectionData.codec = unbox[bool](tmpBox)
-    
+
     entryOpt = v.lookupAttr("docstring")
     if entryOpt.isSome():
       stEntry = entryOpt.get()
@@ -370,10 +370,10 @@ test "samiconf":
   spec.addGlobalAttr("output_file",
                      "string",
                      some(box("sami-extractions.json")))
-  
+
   var sectKey = spec.addSection("key", validSubSecs =
     @["*", "*.json", "*.binary"])
-  
+
   sectKey.addAttr("required", "bool", some(box(false)))
   sectKey.addAttr("missing_action", "string", some(box("warn")))
   sectKey.addAttr("system", "bool", some(box(false)))
@@ -396,7 +396,7 @@ test "samiconf":
   let ctx = tree.evalTree().getOrElse(nil)
   check ctx != nil
 
-  ctx.addSpec(spec)  
+  ctx.addSpec(spec)
   check ctx.validateConfig()
 
   var conf = ctx.loadSamiConfig()

--- a/tests/test8.nim
+++ b/tests/test8.nim
@@ -17,6 +17,11 @@ for i from 0 to 2 {
 d, e, f := x
 
 echo(string(f[1])) # should be 2
+
+out, status := system("ls")
+
+echo("Output is: ", out)
+echo("Status was: ", string(status))
 """
 
 test "manual inspection":

--- a/tests/test8.nim
+++ b/tests/test8.nim
@@ -1,0 +1,29 @@
+import unittest, logging, streams
+
+import con4m
+
+
+let s = """
+x := (1, "a", [1, 2, 3])
+a := x[0]
+b := x[1]
+c := x[2]
+echo(string(a))
+echo(b)
+for i from 0 to 2 {
+  echo(string(c[i]))
+}
+
+d, e, f := x
+
+echo(string(f[1])) # should be 2
+"""
+
+test "manual inspection":
+  addHandler(newConsoleLogger(fmtStr = "$appname: $levelname: "))
+
+  let
+    tree = parse(s.newStringStream())
+    ctx = tree.evalTree().getOrElse(nil)
+  check ctx != nil
+


### PR DESCRIPTION
1) Indexing requires an integer constant for static type checking (though, we *could* evaluate as we check if we really cared; but this is a reasonable and not uncommon limitation).

2) Tuple unpacking syntax does work, but wouldn't work if you put parens around the LHS. That actually wouldn't have to be ambiguous, but I decided I don't like it, because if you support it, it would be irregular to not support nesting, and I utterly hate the Python nested tuple unpack.  I.e., (a, b, (c, d, e)) = x

The below all works:

`x := (1, "a", [1, 2, 3])
a := x[0]
b := x[1]
c := x[2]
echo(string(a))
echo(b)
for i from 0 to 2 {
  echo(string(c[i]))
}

d, e, f := x

echo(string(f[1]))`

Closes #9 
