### PR TITLE
JSon bug fix

### DIFF
--- a/con4m.nimble
+++ b/con4m.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.1"
+version       = "0.3.2"
 author        = "John Viega"
 description   = "A generic configuration file format that allows for lightweight scripting. Inspired by HCL, but far more straightforward.  Yet far more functional than UCL."
 license       = "Apache-2.0"

--- a/src/con4m/box.nim
+++ b/src/con4m/box.nim
@@ -223,10 +223,11 @@ proc boxToJson*(b: Box): string =
             result = result & item.boxToJSon()
         result = result & "]"
     of MkTable:
+        result = "{ "
         for k, val in b.t.t:
             if addComma: result = result & ", " else: addComma = true
             result = result & boxToJson(k) & " : " & boxToJson(val)
-        result = result & "}"
+        result = result & " }"
     else:
         return "null" # Boxed objects not supported
 


### PR DESCRIPTION
Was not outputting the { for embedded tables.  Fixed that, bumped version to 0.3.1.