### PR TITLE
Fix names to match header / sources + consistency tweaks

### DIFF
--- a/src/c/con4m.h
+++ b/src/c/con4m.h
@@ -233,11 +233,11 @@ extern AttrErr  c4mSetAttrFloat(C4State, char *, float);
  */
 extern AttrErr  c4mSetAttr(C4State, char *, Box);
 
-/* BoxType c4BoxType(Box);
+/* BoxType c4mBoxType(Box);
  *
  * Returns the outmost type of a box.
  */
-extern BoxType c4BoxType(Box);
+extern BoxType c4mBoxType(Box);
 
 /* int64_t c4mUnpackInt(Box)
  *
@@ -310,7 +310,7 @@ extern Box      c4mPackInt(int64_t);
 extern Box      c4mPackBool(int64_t);
 extern Box      c4mPackArray(Box *, int64_t);
 
-/* NimDict c4DictNew();
+/* NimDict c4mDictNew();
  *
  * Creates a new NimDict object.  It will need deallocation.
  */
@@ -350,7 +350,7 @@ extern void     c4mDictKeyDel(NimDict, Box);
  */
 extern C4Spec   c4mLoadSpec(char *, char *, int64_t *);
 
-/* int64_t  c4GetSections(C4State, char *, char ***);
+/* int64_t  c4mGetSections(C4State, char *, char ***);
  *
  * Given a fully-qualified path to a section, produces an array
  * containing the names of all defined sections.  The return value is
@@ -364,9 +364,9 @@ extern C4Spec   c4mLoadSpec(char *, char *, int64_t *);
  *
  * The return value is the number of items in the array that is passed back.
  */
-extern int64_t  c4GetSections(C4State, char *, char ***);
+extern int64_t  c4mGetSections(C4State, char *, char ***);
 
-/* int64_t  c4GetFields(C4State, char *, char ***);
+/* int64_t  c4mGetFields(C4State, char *, char ***);
  *
  * Given a fully-qualified path to a section, produces an array
  * containing the names of all defined fields in that section,
@@ -383,9 +383,9 @@ extern int64_t  c4GetSections(C4State, char *, char ***);
  *
  * The return value is the number of items in the array that is passed back.
  */
-extern int64_t  c4GetFields(C4State, char *, char ***);
+extern int64_t  c4mGetFields(C4State, char *, char ***);
 
-/* int64_t  c4EnumerateScope(C4State, char *, char ***);
+/* int64_t  c4mEnumerateScope(C4State, char *, char ***);
  *
  * Given a fully-qualified path to a section, produces an array
  * containing the names of all defined fields in that section,
@@ -403,7 +403,7 @@ extern int64_t  c4GetFields(C4State, char *, char ***);
  *
  * The return value is the number of items in the array that is passed back.
  */
-extern int64_t  c4EnumerateScope(C4State, char *, char ***);
+extern int64_t  c4mEnumerateScope(C4State, char *, char ***);
 // Below are all deallocation functions.
 extern void     c4mClose(C4State);
 extern char *   c4mGetSpecErr(C4Spec);

--- a/src/con4m/capi.nim
+++ b/src/con4m/capi.nim
@@ -203,9 +203,9 @@ proc c4mGetAttr*(state:   ConfigState,
 
   GC_ref(result)
 
-proc c4GetSections*(state: ConfigState,
-                    name:  cstring,
-                    arr:   var ptr cstring): int {.exportc.} =
+proc c4mGetSections*(state: ConfigState,
+                     name:  cstring,
+                     arr:   var ptr cstring): int {.exportc.} =
   var res: seq[cstring] = @[]
 
   let
@@ -235,9 +235,9 @@ proc c4GetSections*(state: ConfigState,
   return len(res)
 
 
-proc c4GetFields*(state: ConfigState,
-                  name:  cstring,
-                  arr:   var ptr cstring): int {.exportc.} =
+proc c4mGetFields*(state: ConfigState,
+                   name:  cstring,
+                   arr:   var ptr cstring): int {.exportc.} =
   var res: seq[cstring] = @[]
 
   let
@@ -268,9 +268,9 @@ proc c4GetFields*(state: ConfigState,
   return len(res)
 
 
-proc c4EnumerateScope*(state: ConfigState,
-                       name:  cstring,
-                       arr:   var ptr cstring): int {.exportc.} =
+proc c4mEnumerateScope*(state: ConfigState,
+                        name:  cstring,
+                        arr:   var ptr cstring): int {.exportc.} =
 
   var res: seq[cstring] = @[]
 


### PR DESCRIPTION
Fix the name `c4BoxType` to `c4mBoxType` to match the exported symbol name.
Fix a few other names with a `c4` prefix to use a `c4m` prefix for consistency with all other names.