### PR TITLE
fix(buildlibs.sh): Small changes to the buildlibs.sh script to provide macOS compatibility 

### DIFF
--- a/files/bin/buildlibs.sh
+++ b/files/bin/buildlibs.sh
@@ -226,8 +226,23 @@ function ensure_gumbo {
     if ! copy_from_package libgumbo.a ; then
         ensure_musl
         get_src sigil-gumbo https://github.com/Sigil-Ebook/sigil-gumbo/
-        sed -i.bakconf4mbak '/examples/d' CMake*
-        rm *.bakconf4mbak
+        colorln CYAN "Watching our waistline, selecting only required gumbo ingredients...."
+        cat > CMakelists.txt <<EOL
+cmake_minimum_required( VERSION 3.0 ) 
+
+project(gumbo) 
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY \${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY \${PROJECT_BINARY_DIR}/.libs)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY \${PROJECT_BINARY_DIR}/.libs)
+
+set(TOP_BUILD_LEVEL \${PROJECT_BINARY_DIR})
+
+set(GUMBO_STATIC_LIB 1)
+set(GUMBO_IS_SUBTREE 0)
+
+add_subdirectory(src/)
+EOL
         colorln CYAN "Cooking up some gumbo"
         mkdir build
         cd build

--- a/files/bin/buildlibs.sh
+++ b/files/bin/buildlibs.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
+OS=$(uname -o 2>/dev/null)
+if [[ ${?} != 0 ]] ; then
+    # Older macOS/OSX versions of uname don't support -o
+    OS=$(uname -s)
+fi
 
 set -eEu
 set -o pipefail
 
 ARCH=$(uname -m)
-OS=$(uname -o)
 
 if [[ ${ARCH} = "x86_64" ]] ; then
     NIMARCH=amd64

--- a/files/bin/buildlibs.sh
+++ b/files/bin/buildlibs.sh
@@ -223,7 +223,8 @@ function ensure_gumbo {
     if ! copy_from_package libgumbo.a ; then
         ensure_musl
         get_src sigil-gumbo https://github.com/Sigil-Ebook/sigil-gumbo/
-        sed -i '/examples/d' CMake*
+        sed -i.bakconf4mbak '/examples/d' CMake*
+        rm *.bakconf4mbak
         colorln CYAN "Cooking up some gumbo"
         mkdir build
         cd build

--- a/files/bin/buildlibs.sh
+++ b/files/bin/buildlibs.sh
@@ -228,9 +228,9 @@ function ensure_gumbo {
         get_src sigil-gumbo https://github.com/Sigil-Ebook/sigil-gumbo/
         colorln CYAN "Watching our waistline, selecting only required gumbo ingredients...."
         cat > CMakelists.txt <<EOL
-cmake_minimum_required( VERSION 3.0 ) 
+cmake_minimum_required( VERSION 3.0 )
 
-project(gumbo) 
+project(gumbo)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY \${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY \${PROJECT_BINARY_DIR}/.libs)

--- a/files/bin/buildlibs.sh
+++ b/files/bin/buildlibs.sh
@@ -21,8 +21,7 @@ else
 fi
 
 DEPS_DIR=${DEPS_DIR:-${HOME}/.local/c0}
-
-PKG_LIBS=${1}/lib/${OS}-${NIMARCH}
+PKG_LIBS=${1:-"./files/deps"}/lib/${OS}-${NIMARCH}
 MY_LIBS=${DEPS_DIR}/libs
 SRC_DIR=${DEPS_DIR}/src
 MUSL_DIR=${DEPS_DIR}/musl


### PR DESCRIPTION
macOS uses BSD `sed` which errors out with the attempted usage of `-i` for 'inplace'. ~The provided alternative is pretty gross but is cross-platform in terms of BSD & GNU `sed`~. Replaced whole sed approach with just dumping a `CMakelists.txt` file of predefined structure.

The provision of a default argument to the `${1}` variable was needed to avoid an unset parameter error on macOS, I expect the root cause here to be whatever the version of bash macOS is using and whatever vintage it is vs current bash mainline.

Older versions of macOS/OSX ship with a version of `uname` that doesn't not support the `-o` switch for collecting OS version, it instead uses `-s`. Fix tries `uname -o` first and if that fails falls back to `uname -s`. 