### PR TITLE
fix(buildlibs.sh): move env sets to further into file to avoid exiting too early on macOS x64

### DIFF
--- a/files/bin/buildlibs.sh
+++ b/files/bin/buildlibs.sh
@@ -26,8 +26,6 @@ if [[ ${#} -eq 0 ]] ; then
     colorln RED Script requires an argument pointing to the deps directory
     exit 1
 fi
-set -eEu
-set -o pipefail
 
 ARCH=$(uname -m)
 OS=$(uname -o 2>/dev/null)
@@ -35,6 +33,9 @@ if [[ ${?} != 0 ]] ; then
     # Older macOS/OSX versions of uname don't support -o
     OS=$(uname -s)
 fi
+
+set -eEu
+set -o pipefail
 
 if [[ ${OS} = "Darwin" ]] ; then
     # Not awesome, but this is what nim calls it.


### PR DESCRIPTION
Tiny change to just move the env sets of :

```
set -eEu
set -o pipefail
```
a few lines further down to avoid exiting too early on macOS x64. We use the failing exit status of `uname -o` to determine we are on macOS x64 but with those env sets already made we exit and never get to the test of the return value.
