### PR TITLE
ci: add tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # 4.1.4
 
       - name: Install Nim
-        uses: iffy/install-nim@c76b9157e544576bf61c932ee66ff3c7d194deb9 # v5.0.4
+        uses: iffy/install-nim@c76b9157e544576bf61c932ee66ff3c7d194deb9 # 5.0.4
         with:
           version: "binary:2.0.0"
         env:


### PR DESCRIPTION
Add a workflow that runs `nimble build` and `test`.

The tests currently fail, ~so make the workflow indicate success even if the tests fail for now. This workflow is still useful because it ensures that `nimble build` succeeds - that command errored on Linux until recently (https://github.com/crashappsec/con4m/pull/128).~

Closes #121

---

To-do:

- [x] Consider either:
   - [ ] requiring a PR to push to the `jtv/v2` branch
   - [x] or running this tests workflow on push to `jtv/v2`
- [ ] Consider not running on push to `dev` if we won't use that branch in the future