### PR TITLE
add prompt attribute to component parameters

### DIFF
--- a/files/con4m/types.nim
+++ b/files/con4m/types.nim
@@ -320,6 +320,7 @@ type
     defaultType*:   Con4mType
     defaultCb*:     Option[CallbackObj]
     value*:         Option[Box]
+    prompt*:        bool # wheter to prompt user for the value or use default only
 
 let
   # These are just shared instances for types that aren't


### PR DESCRIPTION
this will be required for some of the signing improvements in chalk

the idea is that this will allow to add parameters in components which only auto-compute values via default callback and will never prompt the user for the value during chalk load. This way we can store the computer value in chalkmark for easy on subsequent executions without any user interaction.