### PR TITLE
fix index out of bound in slice function

### DIFF
--- a/files/con4m/builtins.nim
+++ b/files/con4m/builtins.nim
@@ -305,8 +305,11 @@ proc c4mSlice*(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
   if endix < 0:
     endix += s.len()
 
+  endix   = min(endix, s.len())
+  startix = min(max(startix, 0), endix)
+
   try:
-    return some(pack(s[startix .. endix]))
+    return some(pack(s[startix ..< endix]))
   except:
     return some(pack(""))
 
@@ -321,16 +324,17 @@ proc c4mSliceToEnd*(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
 
   let
     s       = unpack[string](args[0])
-    endix   = s.len() - 1
+    endix   = s.len()
   var
     startix = unpack[int](args[1])
-
 
   if startix < 0:
     startix += s.len()
 
+  startix = min(max(startix, 0), endix)
+
   try:
-    return some(pack(s[startix .. endix]))
+    return some(pack(s[startix ..< endix]))
   except:
     return some(pack(""))
 


### PR DESCRIPTION
tested with:

```
a := "12345"
info(slice(a, 0, 0))
info(slice(a, 0, 1))
info(slice(a, 0, 2))
info(slice(a, 0, 3))
info(slice(a, 0, 4))
info(slice(a, 0, 5))
info(slice(a, 0, 6))
info(slice(a, 0, 7))
info("====")
info(slice(a, 0, -1))
info(slice(a, -1, -1))
info(slice(a, -2, -1))
info(slice(a, -3, -1))
info(slice(a, -4, -1))
info(slice(a, -6, -1))
info(slice(a, -7, -1))
info("====")
info(slice(a, 8, 5))
info(slice(a, 3, 1))
```

which yields:

```
info:
info:  1
info:  12
info:  123
info:  1234
info:  12345
info:  12345
info:  12345
info:  ====
info:  1234
info:
info:  4
info:  34
info:  234
info:  1234
info:  1234
info:  ====
info:
info:
```
