### PR TITLE
fix: use nimutils fork() in run/system builtins to avoid BusyBox timeout hang

### DIFF
--- a/files/con4m/builtins.nim
+++ b/files/con4m/builtins.nim
@@ -1340,8 +1340,8 @@ when defined(posix):
 
     unprivileged:
       logExternalAction("run", cmd)
-      let (output, _) = execCmdEx(cmd)
-      result = some(pack(output))
+      let output = runCmdGetEverything("/bin/sh", @["-c", cmd])
+      result = some(pack(output.getStdout() & output.getStderr()))
 
   proc c4mSystem*(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
     ## Generally exposed as `system(s)`
@@ -1354,9 +1354,9 @@ when defined(posix):
 
     unprivileged:
       logExternalAction("run", cmd)
-      let (output, exitCode) = execCmdEx(cmd)
-      outlist.add(pack(output))
-      outlist.add(pack(exitCode))
+      let output = runCmdGetEverything("/bin/sh", @["-c", cmd])
+      outlist.add(pack(output.getStdout() & output.getStderr()))
+      outlist.add(pack(output.getExit()))
 
     result = some(pack(outlist))
 


### PR DESCRIPTION
## Summary

- Replace `execCmdEx` with `runCmdGetEverything("/bin/sh", ...)` in the `run()` and `system()` con4m builtins
- Combines stdout and stderr to preserve existing behavior (`execCmdEx` uses `poStdErrToStdOut` by default)

## Root cause

On Alpine Linux, `execCmdEx` uses `clone(CLONE_VM|CLONE_VFORK)` to spawn `sh`, making the caller the kernel parent of the entire subprocess chain. BusyBox `timeout` uses a "replace + watchdog" architecture: it execs itself into the target command and leaves a watchdog process to kill it on alarm. The watchdog detects liveness via `kill(pid, 0)`, which returns success for zombie processes.

When the command finishes, it exits and becomes a zombie under the caller (which is blocked reading the pipe and cannot call `waitpid`). The watchdog sees `kill(pid, 0) = 0` and keeps running — holding the pipe write end open — for the full timeout duration.

`runCmdGetEverything` uses a regular `fork()` with a select-loop that calls `wait4(WNOHANG)` every ~1s, reaping the zombie promptly. The watchdog then gets `ESRCH` and exits, closing the pipe immediately.

## Test plan

```shell
# Alpine with syft installed and a 30s syft_timeout: should complete in ~10s, not 40s
make tests args="test_docker.py -k sbom -x"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)